### PR TITLE
Add distance matrix to design class

### DIFF
--- a/qnd/design.py
+++ b/qnd/design.py
@@ -1,5 +1,6 @@
 
 import  scipy
+from scipy import spatial
 
 class Design ( object ) :
 
@@ -36,6 +37,12 @@ class Design ( object ) :
         """List of Point objects."""
         return [ self[ index ] for index in range( len( self ) ) ]
 
+    @property
+    def distance_matrix(self):
+        """Euclidean pairwise distance matrix in scaled space."""
+        return spatial.distance.squareform(
+            spatial.distance.pdist(self.unscaled))
+        
     @property
     def compliance( self ) :
         """True for Points satisfying constraints, False otherwise."""

--- a/qnd/design.py
+++ b/qnd/design.py
@@ -1,6 +1,5 @@
 
 import  scipy
-from scipy import spatial
 
 class Design ( object ) :
 
@@ -41,11 +40,10 @@ class Design ( object ) :
         """Euclidean pairwise distance matrix in scaled space.  If squareform
         is flagged, return the full distance matrix, else return the
         flattened upper triangle."""
-        if squareform:
-            return spatial.distance.squareform(
-                spatial.distance.pdist(self.unscaled))
-        else:
-            return spatial.distance.pdist(self.unscaled)
+        d = self.scaled[:, None] - self.scaled[None, :]
+        mat = scipy.sqrt((d**2).sum(axis=2))
+        n = len(self)
+        return mat if squareform else mat[scipy.triu_indices(n, 1)]
         
     @property
     def compliance( self ) :

--- a/qnd/design.py
+++ b/qnd/design.py
@@ -37,11 +37,15 @@ class Design ( object ) :
         """List of Point objects."""
         return [ self[ index ] for index in range( len( self ) ) ]
 
-    @property
-    def distance_matrix(self):
-        """Euclidean pairwise distance matrix in scaled space."""
-        return spatial.distance.squareform(
-            spatial.distance.pdist(self.unscaled))
+    def distance_matrix(self, squareform=True):
+        """Euclidean pairwise distance matrix in scaled space.  If squareform
+        is flagged, return the full distance matrix, else return the
+        flattened upper triangle."""
+        if squareform:
+            return spatial.distance.squareform(
+                spatial.distance.pdist(self.unscaled))
+        else:
+            return spatial.distance.pdist(self.unscaled)
         
     @property
     def compliance( self ) :

--- a/qnd/design.py
+++ b/qnd/design.py
@@ -39,11 +39,10 @@ class Design ( object ) :
     def distance_matrix(self, squareform=True):
         """Euclidean pairwise distance matrix in scaled space.  If squareform
         is flagged, return the full distance matrix, else return the
-        flattened upper triangle."""
+        flattened upper triangle without the main diagonal."""
         d = self.scaled[:, None] - self.scaled[None, :]
         mat = scipy.sqrt((d**2).sum(axis=2))
-        n = len(self)
-        return mat if squareform else mat[scipy.triu_indices(n, 1)]
+        return mat if squareform else mat[scipy.triu_indices(len(self), 1)]
         
     @property
     def compliance( self ) :


### PR DESCRIPTION
Now you can access the euclidean distance matrix for the scaled representation of your design in full or condensed form using

``` python
    design.distance_matrix()
```
